### PR TITLE
feat: Update jitoSOL docs validator endpoints for pf fields

### DIFF
--- a/jitosol/jitosol-liquid-staking/for-developers/index.md
+++ b/jitosol/jitosol-liquid-staking/for-developers/index.md
@@ -26,21 +26,27 @@ Parameters:
       "mev_commission_bps": 10000,
       "mev_rewards": 4438669326,
       "running_jito": true,
-      "active_stake": 57968373482697
+      "active_stake": 57968373482697,
+      "priority_fee_commission_bps": 5000,
+      "priority_fee_rewards": 31269273876
     },
     {
       "vote_account": "B6nDYYLc2iwYqY3zdmavMmU9GjUL2hf79MkufviM2bXv",
       "mev_commission_bps": 500,
       "mev_rewards": 9214553780,
       "running_jito": true,
-      "active_stake": 598871747692941
+      "active_stake": 598871747692941,
+      "priority_fee_commission_bps": 5000,
+      "priority_fee_rewards": 94572974753
     },
     {
       "vote_account": "2PpHNHPLseBb4doTu1ajTwAxCrjmu7ubReDHKPrjxi9F",
       "mev_commission_bps": 800,
       "mev_rewards": 6123234290,
-      "rq9qunning_jito": true,
+      "running_jito": true,
       "active_stake": 88295901191147
+      "priority_fee_commission_bps": 5000,
+      "priority_fee_rewards": 85937362840,
     }...
   ]}</code></pre>
 
@@ -60,37 +66,51 @@ Parameters: None
   {
     "epoch": 608,
     "mev_commission_bps": 10000,
-    "mev_rewards": 59355050
+    "mev_rewards": 59355050,
+    "priority_fee_commission_bps": 5000,
+    "priority_fee_rewards": 43328291
   },
   {
     "epoch": 607,
     "mev_commission_bps": 10000,
-    "mev_rewards": 31870726
+    "mev_rewards": 31870726,
+    "priority_fee_commission_bps": 5000,
+    "priority_fee_rewards": 23288520
   },
   {
     "epoch": 605,
     "mev_commission_bps": 10000,
-    "mev_rewards": 535874838
+    "mev_rewards": 535874838,
+    "priority_fee_commission_bps": 5000,
+    "priority_fee_rewards": 388885626
   },
   {
     "epoch": 604,
     "mev_commission_bps": 10000,
-    "mev_rewards": 29926950
+    "mev_rewards": 29926950,
+    "priority_fee_commission_bps": 5000,
+    "priority_fee_rewards": 21809850
   },
   {
     "epoch": 603,
     "mev_commission_bps": 10000,
-    "mev_rewards": 46862475
+    "mev_rewards": 46862475,
+    "priority_fee_commission_bps": 5000,
+    "priority_fee_rewards": 34125000
   },
   {
     "epoch": 602,
     "mev_commission_bps": 10000,
-    "mev_rewards": 939666610
+    "mev_rewards": 939666610,
+    "priority_fee_commission_bps": 5000,
+    "priority_fee_rewards": 682500000
   },
   {
     "epoch": 601,
     "mev_commission_bps": 10000,
-    "mev_rewards": 254418752
+    "mev_rewards": 254418752,
+    "priority_fee_commission_bps": 5000,
+    "priority_fee_rewards": 184687500
   },
 ]</code></pre>
 
@@ -127,6 +147,7 @@ Gets total MEV rewards, Jito stake weight, and MEV rewards per lamport for the n
   "jito_stake_weight_lamports": 287482861698565570,
   "mev_reward_per_lamport": 5.034038244866689e-05
 }</code>
+
 
 ### GET /api/v1/daily_mev_rewards
 

--- a/jitosol/jitosol-liquid-staking/mev-and-staker-rewards-api-info/index.md
+++ b/jitosol/jitosol-liquid-staking/mev-and-staker-rewards-api-info/index.md
@@ -42,6 +42,8 @@ Method: GET
       "epoch": 678,
       "amount": 23308599,
       "claim_status_account": "D6WY3PX2eeyoBCxSybBjH2YoZh7c1pWg5W5DQAj1Lwza"
+      "priority_fee_claim_status_account": "9gUWLZUgkZiKEL4Yt6qJ2nDM33s1pKczCV7nJVg8iEH",
+      "priority_fee_amount": 1165429,
     },
     {
       "claimant": "J9gUWLZUgkZiKEL4Yt6qJ2nDM33s1pKczCV7nJVg8iEH",
@@ -51,6 +53,8 @@ Method: GET
       "epoch": 678,
       "amount": 23307187,
       "claim_status_account": "BuCtcuqrzWEJoP5prgSYiUJKbPzhFZRjPXEzjopZY2cj"
+      "priority_fee_claim_status_account": "HJUv4xr2EvNNLX14PFK16kyftyNW9ydd7WyWKPutV4nJ",
+      "priority_fee_amount": 1165359
     }
   ],
   "total_count": 1170170
@@ -90,7 +94,9 @@ Method: GET
       "mev_commission": 0,
       "num_stakers": 1422,
       "epoch": 678,
-      "claim_status_account": "6m7RcCGGh9bzWuuyVuZYm7jzqp3vv5vCnxWSpsBVN2FY"
+      "claim_status_account": "6m7RcCGGh9bzWuuyVuZYm7jzqp3vv5vCnxWSpsBVN2FY",
+      "priority_fee_commission": 5000,
+      "priority_fee_amount": 35994787863
     },
     {
       "vote_account": "CcaHc2L43ZWjwCHART3oZoJvHLAe9hzT2DJNUpBzoTN1",
@@ -98,11 +104,12 @@ Method: GET
       "mev_commission": 700,
       "num_stakers": 5297,
       "epoch": 678,
-      "claim_status_account": "GpYrV3H9WWkVff6QeMJcePYnFLm7dbpL1ogmPmiHL7VM"
+      "claim_status_account": "GpYrV3H9WWkVff6QeMJcePYnFLm7dbpL1ogmPmiHL7VM",
+      "priority_fee_commission": 5000,
+      "priority_fee_amount": 33378071423
     }
   ],
   "total_count": 1083
 }</code></pre>
 
-Both endpoints return paginated results and support filtering and sorting options. The response includes the requested rewards data and a total count of matching records.
-
+Both endpoints return paginated results and support filtering and sorting options. The response includes the requested rewards data and a total count of matching records. Validator rewards do not have a priority fee claim status account due to the flow of funds in priority fee distribution. Priority fee rewards are sent from the Validator to the priority fee distribution account and a Validator claim is not needed.


### PR DESCRIPTION
**Problem**
JitoSOL docs do not reflect upcoming changes to the validator responses returned from Kobe API.

**Solution**
- Document additional fields on the /validators response
- Document additional fields on the /validators/{validator} response
- Document staker reward changes
- Document validator reward changes